### PR TITLE
Default to HTTPS, use env var for token

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,37 +1,64 @@
 use error::*;
-use olifants;
+use olifants::timeline::Endpoint;
+use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
-pub struct Opt {
+struct Opt {
     #[structopt(short = "i", long = "instance",
-                help = "Instance URL (HTTPS is assumed if protocol is unspecified)")]
+                help = "Instance URL (if protocol is absent, `https` is assumed)")]
     pub instance: String,
 
-    #[structopt(short = "t", long = "token", help = "Access token")]
-    pub access_token: String,
+    #[structopt(short = "t", long = "token",
+                help = "Access token. If unspecified, uses the \
+                        `MASTODON_ACCESS_TOKEN` environment variable.")]
+    pub token: Option<String>,
 
-    #[structopt(help = "Stream type")]
-    pub stream_type: StreamType,
+    #[structopt(long = "timeline", help = "Timeline type", default_value = "local",
+                possible_value = "local", possible_value = "federated", possible_value = "user")]
+    pub timeline: String,
 }
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct StreamType(pub olifants::timeline::Endpoint);
+pub struct Args {
+    pub instance_url: String,
+    pub access_token: String,
+    pub endpoint: Endpoint,
+}
 
-impl ::std::str::FromStr for StreamType {
-    type Err = Error;
+impl Args {
+    pub fn init() -> Result<Self> {
+        let args = Opt::from_args();
 
-    fn from_str(s: &str) -> Result<Self> {
+        // If no protocol specified, assume `https://`
+        let instance_url =
+            if args.instance.starts_with("http://") || args.instance.starts_with("https://") {
+                args.instance
+            } else {
+                format!("https://{}", args.instance)
+            };
+
+        let access_token = args.token
+            .or_else(|| ::std::env::var("MASTODON_ACCESS_TOKEN").ok())
+            .ok_or_else(|| {
+                let msg = "please specify an access token with `--token`, or by \
+                       setting the `MASTODON_ACCESS_TOKEN` environment variable";
+                Error::from_kind(ErrorKind::Msg(msg.into()))
+            })?;
+
         use olifants::timeline::Endpoint::*;
 
-        let result = match s {
+        let endpoint = match args.timeline.as_ref() {
             "user" => User,
             "notification" => Notification,
             "notifications" => Notification,
             "federated" => Federated,
             "local" => Local,
-            other => Other(other.to_string()), // TODO: Error
+            other => Other(other.to_string()), // TODO: Error?
         };
 
-        Ok(StreamType(result))
+        Ok(Args {
+            instance_url,
+            access_token,
+            endpoint,
+        })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod error;
 mod args;
 
 use ansi_term::Colour;
+use args::Args;
 use chrono::offset::Local;
 use error::*;
 use futures::Stream;
@@ -25,7 +26,6 @@ use html5ever::tendril::TendrilSink;
 use olifants::Client;
 use std::default::Default;
 use std::string::String;
-use structopt::StructOpt;
 use tokio_core::reactor::Core;
 
 quick_main!(|| -> Result<()> {
@@ -35,11 +35,10 @@ quick_main!(|| -> Result<()> {
     )?;
 
 
-    let opt = args::Opt::from_args();
+    let args = Args::init()?;
 
-    // TODO: Assume HTTPS for instance if protocol unspecified
     let timeline = client
-        .timeline(&opt.instance, opt.access_token, opt.stream_type.0)
+        .timeline(&args.instance_url, args.access_token, args.endpoint)
         .for_each(|event| {
             use olifants::timeline::Event::*;
 
@@ -50,6 +49,8 @@ quick_main!(|| -> Result<()> {
 
             Ok(())
         });
+
+    println!("Connecting to {}", args.instance_url);
 
     core.run(timeline).chain_err(|| "timeline failed")
 });


### PR DESCRIPTION
* Default to HTTPS if protocol unspecified
* Use MASTODON_ACCESS_TOKEN env variable if present